### PR TITLE
Arreglados errores de diálogos

### DIFF
--- a/Drakhtar/Dialog.cpp
+++ b/Drakhtar/Dialog.cpp
@@ -2,10 +2,10 @@
 
 
 
-Dialog::Dialog(Game* game, ifstream& file, Font* textFont)
+Dialog::Dialog(Game* game, ifstream& file, Font* textFont, SDL_Rect dialogRect): dialogRect_(dialogRect) 
 {
 	readFromFile(file);
-	characterPortraitSprite = new GameObject(TextureManager::get(spriteText), Vector2D<int>(200, 345), Vector2D<int>(150, 150));
+	characterPortraitSprite = new GameObject(TextureManager::get(spriteText), Vector2D<int>(dialogRect_.x + 200, dialogRect_.y + 345), Vector2D<int>(dialogRect_.w*150, dialogRect_.h*150));
 
 	SDL_Color textColor;
 	textColor.r = 0;
@@ -13,8 +13,8 @@ Dialog::Dialog(Game* game, ifstream& file, Font* textFont)
 	textColor.b = 0;
 	textColor.a = 1;
 
-	characterNameSprite = new Text(game->getRenderer(), textFont, Vector2D<int>(600, 370), textColor, characterName);
-	dialogTextSprite = new Text(game->getRenderer(), textFont, Vector2D<int>(110, 450), textColor, dialogText);
+	characterNameSprite = new Text(game->getRenderer(), textFont, Vector2D<int>(dialogRect_.x + 600, dialogRect_.y + 400), textColor, characterName);
+	dialogTextSprite = new Text(game->getRenderer(), textFont, Vector2D<int>(dialogRect_.x + 120, dialogRect_.y + 450), textColor, dialogText);
 }
 
 

--- a/Drakhtar/Dialog.h
+++ b/Drakhtar/Dialog.h
@@ -19,8 +19,10 @@ private:
 	GameObject* characterPortraitSprite = nullptr;
 	Text* characterNameSprite = nullptr;
 	Text* dialogTextSprite = nullptr;
+
+	SDL_Rect dialogRect_;
 public:
-	Dialog(Game* game, ifstream& file, Font* textfont);
+	Dialog(Game* game, ifstream& file, Font* textfont, SDL_Rect dialogRect);
 	~Dialog();
 	virtual void render() const;
 	void readFromFile(ifstream& file);

--- a/Drakhtar/DialogScene.cpp
+++ b/Drakhtar/DialogScene.cpp
@@ -3,7 +3,7 @@
 DialogScene::DialogScene(Game* game, string filename, string fontfile): GameObject(nullptr, Vector2D<int>(0,0), Vector2D<int>(1,1)) // default position and size(adjust it to move DialogScene)
 {
 	dialogBlockSprite = new GameObject(TextureManager::get("UI-dialogueBackground"), Vector2D<int>(getRect().x + WIN_WIDTH - 400, getRect().y + WIN_HEIGHT - 100), Vector2D<int>(getRect().w*600, getRect().h*160));
-	textFont = new Font("../fonts/" + fontfile + ".ttf", 8, dialogBlockSprite->getRect().x + 150);
+	textFont = new Font("../fonts/" + fontfile + ".ttf", 12, dialogBlockSprite->getRect().x + 150);
 	readFromFile(game, "../dialog/" + filename + ".txt",+ textFont);
 }
 

--- a/Drakhtar/DialogScene.cpp
+++ b/Drakhtar/DialogScene.cpp
@@ -1,9 +1,9 @@
 #include "DialogScene.h"
 
-DialogScene::DialogScene(Game* game, string filename, string fontfile)
+DialogScene::DialogScene(Game* game, string filename, string fontfile): GameObject(nullptr, Vector2D<int>(0,0), Vector2D<int>(1,1)) // default position and size(adjust it to move DialogScene)
 {
-	dialogBlockSprite = new GameObject(TextureManager::get("UI-dialogueBackground"), Vector2D<int>(400, 500), Vector2D<int>(600, 160));
-	textFont = new Font("../fonts/" + fontfile + ".ttf", 8);
+	dialogBlockSprite = new GameObject(TextureManager::get("UI-dialogueBackground"), Vector2D<int>(getRect().x + WIN_WIDTH - 400, getRect().y + WIN_HEIGHT - 100), Vector2D<int>(getRect().w*600, getRect().h*160));
+	textFont = new Font("../fonts/" + fontfile + ".ttf", 8, dialogBlockSprite->getRect().x + 150);
 	readFromFile(game, "../dialog/" + filename + ".txt",+ textFont);
 }
 
@@ -17,7 +17,7 @@ DialogScene::~DialogScene()
 	textFont = nullptr;
 }
 
-void DialogScene::render()
+void DialogScene::render() const
 {
 	dialogBlockSprite->render();
 	dialogChain[currentDialogIndex]->render();
@@ -47,7 +47,7 @@ void DialogScene::readFromFile(Game* game, string filename, Font* textFont)
 
 		for (int i = 0;i < dialogChainSize;i++)
 		{
-			dialogChain[i] = new Dialog(game, file, textFont);
+			dialogChain[i] = new Dialog(game, file, textFont, getRect());
 		}
 		
 	//}
@@ -64,7 +64,8 @@ void DialogScene::nextDialog()
 
 void DialogScene::endOfDialog()
 {
+	// close dialog and go to next event(for now it just now restarts the whole dialog)
 	currentDialogIndex = 0;
-	// close dialog and go to next event
+	delete this;
 }
 

--- a/Drakhtar/DialogScene.cpp
+++ b/Drakhtar/DialogScene.cpp
@@ -66,6 +66,6 @@ void DialogScene::endOfDialog()
 {
 	// close dialog and go to next event(for now it just now restarts the whole dialog)
 	currentDialogIndex = 0;
-	delete this;
+	destroy();
 }
 

--- a/Drakhtar/DialogScene.h
+++ b/Drakhtar/DialogScene.h
@@ -10,7 +10,7 @@
 class Game;
 class Dialog;
 
-class DialogScene
+class DialogScene: public GameObject
 {
 private:
 	GameObject* dialogBlockSprite = nullptr;
@@ -21,8 +21,8 @@ private:
 public:
 	DialogScene(Game* game, string filename, string fontfile);
 	~DialogScene();
-	void render();
-	void handleEvents(SDL_Event event);
+	virtual void render() const;
+	virtual void handleEvents(SDL_Event event);
 	void readFromFile(Game* game, string filename, Font* textFont);
 	void nextDialog();
 	void endOfDialog();

--- a/Drakhtar/Font.cpp
+++ b/Drakhtar/Font.cpp
@@ -3,7 +3,7 @@
 
 Font::Font(): font_(nullptr) {}
 
-Font::Font(string filename, int size)
+Font::Font(string filename, int size, int lineJumpLimit): lineJumpLimit_(lineJumpLimit)
 {
 	load(filename, size);
 }
@@ -36,5 +36,6 @@ Font* Font::load(string filename, int size)
 SDL_Surface* Font::renderText(string text, SDL_Color color) const
 {
 	if (font_ == nullptr) return nullptr;
-	return TTF_RenderText_Blended(font_, text.c_str(), color);
+	//return TTF_RenderText_Blended(font_, text.c_str(), color);
+	return TTF_RenderText_Blended_Wrapped(font_, text.c_str(), color, lineJumpLimit_);
 }

--- a/Drakhtar/Font.h
+++ b/Drakhtar/Font.h
@@ -10,10 +10,11 @@ class Font
 {
 private:
 	TTF_Font* font_;
+	int lineJumpLimit_;
 
 public:
 	Font();
-	Font(string filename, int size);
+	Font(string filename, int size, int lineJumpLimit);
 	~Font();
 
 	TTF_Font* getFont() const { return font_; }

--- a/Drakhtar/Game.cpp
+++ b/Drakhtar/Game.cpp
@@ -1,6 +1,18 @@
 #include "Game.h"
 #include "SDLError.h"
 
+Game* Game::instance = nullptr;
+
+Game* Game::getInstance()
+{
+	if (instance == nullptr)
+	{
+		instance = new Game();
+	}
+
+	return instance;
+}
+
 Game::Game()
 	: window_(nullptr), renderer_(nullptr)
 {

--- a/Drakhtar/Game.cpp
+++ b/Drakhtar/Game.cpp
@@ -1,18 +1,6 @@
 #include "Game.h"
 #include "SDLError.h"
 
-Game* Game::instance = nullptr;
-
-Game* Game::getInstance()
-{
-	if (instance == nullptr)
-	{
-		instance = new Game();
-	}
-
-	return instance;
-}
-
 Game::Game()
 	: window_(nullptr), renderer_(nullptr)
 {
@@ -98,4 +86,21 @@ Game::~Game()
 SDL_Renderer* Game::getRenderer()
 {
 	return renderer_;
+}
+
+Game* Game::instance = nullptr;
+
+Game* Game::getInstance()
+{
+	if (instance == nullptr)
+	{
+		instance = new Game();
+	}
+
+	return instance;
+}
+
+State* Game::currentState()
+{
+	return getInstance()->state_;
 }

--- a/Drakhtar/Game.h
+++ b/Drakhtar/Game.h
@@ -28,5 +28,5 @@ public:
 	virtual ~Game();
 	SDL_Renderer* getRenderer();
 	static Game* getInstance();
+	static State* currentState();
 };
-

--- a/Drakhtar/Game.h
+++ b/Drakhtar/Game.h
@@ -16,15 +16,17 @@ class GameStateMachine;
 class Game
 {
 private:
+	static Game* instance;
 	SDL_Window* window_ = nullptr;
 	SDL_Renderer* renderer_ = nullptr;
 	TextureManager* textureManager_ = TextureManager::getInstance();
 	GameStateMachine* stateMachine = nullptr;
 	State* state_ = nullptr;
-public:
 	Game();
+public:
 	void run();
 	virtual ~Game();
 	SDL_Renderer* getRenderer();
+	static Game* getInstance();
 };
 

--- a/Drakhtar/GameObject.cpp
+++ b/Drakhtar/GameObject.cpp
@@ -8,6 +8,7 @@ GameObject::~GameObject()
 	for (auto listener : eventListeners_)
 		delete listener;
 	eventListeners_.clear();
+	setDestroyed(true);
 }
 
 void GameObject::render() const

--- a/Drakhtar/GameObject.cpp
+++ b/Drakhtar/GameObject.cpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "GameObject.h"
+#include "Game.h"
 
 GameObject::~GameObject()
 {
@@ -8,7 +9,6 @@ GameObject::~GameObject()
 	for (auto listener : eventListeners_)
 		delete listener;
 	eventListeners_.clear();
-	setDestroyed(true);
 }
 
 void GameObject::render() const
@@ -38,3 +38,7 @@ SDL_Rect GameObject::getRect() const
 	};
 }
 
+void GameObject::destroy()
+{
+	Game::currentState()->removeGameObject(this);
+}

--- a/Drakhtar/GameObject.h
+++ b/Drakhtar/GameObject.h
@@ -14,12 +14,17 @@ protected:
 	Vector2D<int> size_;
 	Texture* texture_;
 	list<EventListener*> eventListeners_;
+
+	// true if object has been destroyed
+	bool destroyed_;
 public:
 	GameObject(Texture* texture, Vector2D<int> pos, Vector2D<int> size)
-		: texture_(texture), pos_(pos), size_(size) {}
+		: texture_(texture), pos_(pos), size_(size), destroyed_(false) {}
 	virtual ~GameObject();
 	virtual void render() const;
 	virtual void handleEvents(SDL_Event event);
 	GameObject* addEventListener(EventListener* eventListener);
 	SDL_Rect getRect() const;
+	bool getDestroyed() { return destroyed_;  }
+	void setDestroyed(bool destroy) { destroyed_ = destroy; }
 };

--- a/Drakhtar/GameObject.h
+++ b/Drakhtar/GameObject.h
@@ -14,17 +14,13 @@ protected:
 	Vector2D<int> size_;
 	Texture* texture_;
 	list<EventListener*> eventListeners_;
-
-	// true if object has been destroyed
-	bool destroyed_;
 public:
 	GameObject(Texture* texture, Vector2D<int> pos, Vector2D<int> size)
-		: texture_(texture), pos_(pos), size_(size), destroyed_(false) {}
+		: texture_(texture), pos_(pos), size_(size) {}
 	virtual ~GameObject();
 	virtual void render() const;
 	virtual void handleEvents(SDL_Event event);
 	GameObject* addEventListener(EventListener* eventListener);
 	SDL_Rect getRect() const;
-	bool isDestroyed() { return destroyed_;  }
-	void setDestroyed(bool destroy) { destroyed_ = destroy; }
+	void destroy();
 };

--- a/Drakhtar/GameObject.h
+++ b/Drakhtar/GameObject.h
@@ -25,6 +25,6 @@ public:
 	virtual void handleEvents(SDL_Event event);
 	GameObject* addEventListener(EventListener* eventListener);
 	SDL_Rect getRect() const;
-	bool getDestroyed() { return destroyed_;  }
+	bool isDestroyed() { return destroyed_;  }
 	void setDestroyed(bool destroy) { destroyed_ = destroy; }
 };

--- a/Drakhtar/State.cpp
+++ b/Drakhtar/State.cpp
@@ -11,7 +11,8 @@ State::State(Game* game, SDL_Renderer* renderer)
 State::~State()
 {
 	for (auto gameObject : gameObjects_)
-		delete gameObject;
+		if (!gameObject->isDestroyed())
+			delete gameObject;
 	game_ = nullptr;
 }
 
@@ -69,7 +70,7 @@ void State::_render() const
 
 	// Render each game object
 	for (auto gameObject : gameObjects_)
-		if(gameObject->getDestroyed() == false)
+		if (!gameObject->isDestroyed())
 	 		gameObject->render();
 
 	// Render the new frame
@@ -92,7 +93,7 @@ void State::_handleEvents()
 
 		// For each game object, run the event handler
 		for (auto gameObject : gameObjects_)
-			if(gameObject->getDestroyed() == false)
+			if (!gameObject->isDestroyed())
 				gameObject->handleEvents(event);
 	}
 }

--- a/Drakhtar/State.cpp
+++ b/Drakhtar/State.cpp
@@ -12,7 +12,6 @@ State::~State()
 {
 	for (auto gameObject : gameObjects_)
 		delete gameObject;
-	delete exampleDialog_;
 	game_ = nullptr;
 }
 
@@ -27,15 +26,9 @@ void State::_preload()
 	auto box = Tablero->getBoxAt(0, 0);
 	auto box2 = Tablero->getBoxAt(5, 5);
 
-	auto test = new Unit(TextureManager::get("Units-BlueArcher"), box, 2, 10, 5, 5, 5);
-	test->addEventListener(new Controller(test));
-	gameObjects_.push_back(test);
+	auto exampleDialog = new DialogScene(game_, "dialog1_start", "Retron2000");
+	gameObjects_.push_back(exampleDialog);
 
-	auto test2 = new Unit(TextureManager::get("Units-BlueArcher"), box2, 2, 10, 5, 5, 5);
-	test2->addEventListener(new Controller(test2));
-	gameObjects_.push_back(test2);
-
-	exampleDialog_ = new DialogScene(game_, "dialog1_start", "Retron2000");
 }
 
 void State::run()
@@ -76,11 +69,8 @@ void State::_render() const
 
 	// Render each game object
 	for (auto gameObject : gameObjects_)
-	 	gameObject->render();
-
-	//exampleDialog_->render();
-
-	
+		if(gameObject->getDestroyed() == false)
+	 		gameObject->render();
 
 	// Render the new frame
 	SDL_RenderPresent(renderer_);
@@ -102,10 +92,8 @@ void State::_handleEvents()
 
 		// For each game object, run the event handler
 		for (auto gameObject : gameObjects_)
-			gameObject->handleEvents(event);
-
-		//exampleDialog_->handleEvents(event);
-
+			if(gameObject->getDestroyed() == false)
+				gameObject->handleEvents(event);
 	}
 }
 

--- a/Drakhtar/State.h
+++ b/Drakhtar/State.h
@@ -18,6 +18,7 @@ class State
 private:
 	bool _exit = false;
 	list<GameObject*> gameObjects_;
+	list<GameObject*> pendingOnDestroy_;
 	Game* game_ = nullptr;
 protected:
 	SDL_Renderer *renderer_ = nullptr;
@@ -28,7 +29,7 @@ protected:
 	virtual void _handleEvents();
 	virtual void _afterUpdate();
 	virtual void _events();
-	virtual void _destroy() {};
+	virtual void _destroy();
 	virtual void _end() {};
 public:
 	State(Game* game, SDL_Renderer* renderer);

--- a/Drakhtar/State.h
+++ b/Drakhtar/State.h
@@ -18,7 +18,6 @@ class State
 private:
 	bool _exit = false;
 	list<GameObject*> gameObjects_;
-	DialogScene* exampleDialog_;
 	Game* game_ = nullptr;
 protected:
 	SDL_Renderer *renderer_ = nullptr;

--- a/Drakhtar/main.cpp
+++ b/Drakhtar/main.cpp
@@ -11,7 +11,7 @@ int main(int argc, char* argv[]){
 	_CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF); // Check Memory Leaks
 	try
 	{
-		Game *game = new Game();
+		Game *game = Game::getInstance();
 		game->run();
 		delete game;
 		return 0;


### PR DESCRIPTION
Hechos saltos de línea, parámetrizados constructores y diálogo se autodestruye al acabar. Añadida variable destroyed_ a GameObject para indicar si el objeto está destruido.