### PR TITLE
misc: Change static casts to reinterpret casts where actually required

### DIFF
--- a/Drakhtar/EventListeners/UnitStoreController.cpp
+++ b/Drakhtar/EventListeners/UnitStoreController.cpp
@@ -4,8 +4,8 @@
 #include "../Scenes/RecruitScene.h"
 #include "../Structures/Game.h"
 #include "GameObjects/Text.h"
-#include "Managers/TextureManager.h"
 #include "Managers/GameManager.h"
+#include "Managers/TextureManager.h"
 #include "Utils/Constants.h"
 
 UnitStoreController::UnitStoreController(GameObject* gameObject)
@@ -34,7 +34,7 @@ UnitStoreController::~UnitStoreController() {
 }
 
 void UnitStoreController::increaseAmount(StoreUnit* storeUnit) {
-  auto scene = static_cast<RecruitScene*>(  // NOLINT
+  auto scene = reinterpret_cast<RecruitScene*>(
       Game::getSceneMachine()->getCurrentScene());
   if (GameManager::getInstance()->getMoney() >=
       totalCost_ + scene->getCost(storeUnit->type)) {
@@ -46,7 +46,7 @@ void UnitStoreController::increaseAmount(StoreUnit* storeUnit) {
 }
 
 void UnitStoreController::reduceAmount(StoreUnit* storeUnit) {
-  auto scene = static_cast<RecruitScene*>(  // NOLINT
+  auto scene = reinterpret_cast<RecruitScene*>(
       Game::getSceneMachine()->getCurrentScene());
   totalCost_ -= scene->getCost(storeUnit->type);
   storeUnit->amount--;
@@ -55,7 +55,7 @@ void UnitStoreController::reduceAmount(StoreUnit* storeUnit) {
 }
 
 void UnitStoreController::buyUnits() {
-  auto scene = static_cast<RecruitScene*>(  // NOLINT
+  auto scene = reinterpret_cast<RecruitScene*>(
       Game::getSceneMachine()->getCurrentScene());
   for (auto& i : unitStore_) {
     if (i->amount > 0) {
@@ -77,8 +77,7 @@ void UnitStoreController::reset() {
   }
 
   totalCost_ = 0;
-  static_cast<RecruitScene*>(  // NOLINT
-      Game::getSceneMachine()->getCurrentScene())
+  reinterpret_cast<RecruitScene*>(Game::getSceneMachine()->getCurrentScene())
       ->updateTotalCostText(0);
 }
 

--- a/Drakhtar/GameObjects/Board.cpp
+++ b/Drakhtar/GameObjects/Board.cpp
@@ -39,7 +39,7 @@ SDL_Rect Board::getRect() const {
 }
 
 Box *Board::getBoxAt(const int x, const int y) const {
-  return static_cast<Box *>(children_[x * rows_ + y]);  // NOLINT
+  return reinterpret_cast<Box *>(children_[x * rows_ + y]);
 }
 
 Box *Board::getBoxAtCoordinates(const SDL_Point point) const {
@@ -141,7 +141,7 @@ void Board::highlightEnemiesInRange(Box *box, const int range) {
 
 void Board::resetCellsToBase() {
   for (const auto box : children_)
-    static_cast<Box *>(box)->setCurrentTexture(TextureInd::BASE);  // NOLINT
+    reinterpret_cast<Box *>(box)->setCurrentTexture(TextureInd::BASE);
 }
 
 std::list<Vector2D<int>> Board::findPath(const Vector2D<int> &start,

--- a/Drakhtar/GameObjects/DialogScene.cpp
+++ b/Drakhtar/GameObjects/DialogScene.cpp
@@ -104,5 +104,5 @@ void DialogScene::readFromFile(const std::string& filename, Font* textFont,
 }
 
 void DialogSceneOnClick::onClickStop(SDL_Point point) {
-  static_cast<DialogScene*>(getGameObject()->getParent())->next();  // NOLINT
+  reinterpret_cast<DialogScene*>(getGameObject()->getParent())->next();
 }

--- a/Drakhtar/GameObjects/TutorialSequence.cpp
+++ b/Drakhtar/GameObjects/TutorialSequence.cpp
@@ -102,6 +102,6 @@ void TutorialSequence::render() const {
 }
 
 void TutorialSceneOnClick::onClickStop(SDL_Point point) {
-  static_cast<TutorialSequence *>(getGameObject()->getParent())
-      ->createNextTutorial();  // NOLINT
+  reinterpret_cast<TutorialSequence *>(getGameObject()->getParent())
+      ->createNextTutorial();
 }

--- a/Drakhtar/Structures/Tween.cpp
+++ b/Drakhtar/Structures/Tween.cpp
@@ -9,14 +9,13 @@ Tween::Tween(TweenManager* tweenManager) : tweenManager_(tweenManager) {}
 Tween::~Tween() = default;
 
 Tween* Tween::from(const Vector2D<int>& start) {
-  from_.set(static_cast<double>(start.getX()),   // NOLINT
-            static_cast<double>(start.getY()));  // NOLINT
+  from_.set(static_cast<double>(start.getX()),
+            static_cast<double>(start.getY()));
   return this;
 }
 
 Tween* Tween::to(const Vector2D<int>& end) {
-  to_.set(static_cast<double>(end.getX()),   // NOLINT
-          static_cast<double>(end.getY()));  // NOLINT
+  to_.set(static_cast<double>(end.getX()), static_cast<double>(end.getY()));
   return this;
 }
 


### PR DESCRIPTION
[`reinterpret_cast<T>()`](https://en.cppreference.com/w/cpp/language/reinterpret_cast) is actually dangerous when mis-used as unlike [`static_cast<T>()`](https://en.cppreference.com/w/cpp/language/static_cast), it does not add any CPU instructions (no conversions done whatsoever) therefore no data conversion is done.

The purpose of reinterpret_cast is to assert during compile-time that we acknowledge the compiler those types will always be the type it is, for example, a `Board`'s child will always be a Box, so it makes sense that we reinterpret_cast them to Box when we want to use any of its methods or properties.